### PR TITLE
Fix firmware partition overflow on 4MB flash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _autosave-*
 # Exported BOM files
 *.xml
 *.csv
+!interface_module/firmware/partitions.csv
 
 # Python venv
 .venv

--- a/interface_module/firmware/partitions.csv
+++ b/interface_module/firmware/partitions.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,   Size,     Flags
+nvs,      data, nvs,     0x9000,   0x5000,
+otadata,  data, ota,     0xe000,   0x2000,
+app0,     app,  ota_0,   0x10000,  0x180000,
+app1,     app,  ota_1,   0x190000, 0x180000,
+spiffs,   data, spiffs,  0x310000, 0xE0000,
+coredump, data, coredump,0x3F0000, 0x10000,

--- a/interface_module/firmware/platformio.ini
+++ b/interface_module/firmware/platformio.ini
@@ -13,6 +13,7 @@
 platform = espressif32
 board = esp32doit-devkit-v1
 framework = arduino
+board_build.partitions = partitions.csv
 lib_deps = 
     https://github.com/me-no-dev/ESPAsyncWebServer.git
     https://github.com/me-no-dev/AsyncTCP.git
@@ -32,6 +33,7 @@ extra_scripts =
 platform = espressif32
 board = esp32doit-devkit-v1
 framework = arduino
+board_build.partitions = partitions.csv
 lib_deps = 
     https://github.com/me-no-dev/ESPAsyncWebServer.git
     https://github.com/me-no-dev/AsyncTCP.git


### PR DESCRIPTION
The compiled firmware (~1.28 MB) slightly exceeds the default `ota_0` partition size (1.25 MB = `0x140000` bytes).

This causes the bootloader to silently reject the image and enter an instant reboot loop — no serial output is produced, making the failure very difficult to diagnose. The symptom is the device cycling through the ROM boot message (`entry 0x400805e4`) every ~80 ms with no application output whatsoever.

## Root cause

The default `esp32doit-devkit-v1` partition table allocates 0x140000 (1,310,720 bytes) per OTA slot. The current firmware binary is 1,315,024 bytes — **4,304 bytes over the limit**.

This overflow started appearing as the firmware grew with recent feature additions (OTRSP, band labels, new UI).

## Fix

Add `partitions.csv` with enlarged OTA app partitions (0x180000 = 1,536 KB each) and reference it in both `platformio.ini` build environments.

The SPIFFS partition is reduced from ~1.4 MB to 896 KB, which is still ample for the web interface files (~22 KB compressed).

**New layout (4 MB flash):**

| Name     | Offset     | Size    |
|----------|------------|---------|
| nvs      | 0x9000     | 20 KB   |
| otadata  | 0xe000     | 8 KB    |
| app0     | 0x10000    | **1536 KB** (was 1280 KB) |
| app1     | 0x190000   | **1536 KB** (was 1280 KB) |
| spiffs   | 0x310000   | 896 KB  |
| coredump | 0x3f0000   | 64 KB   |

Also updates `.gitignore` to allow `partitions.csv` alongside the existing `*.csv` exclusion (which targets KiCad BOM exports).

## Testing

Verified on ESP32-D0WD-V3 (rev 3.1), 4 MB flash. Device boots, connects to WiFi, and serves the web interface correctly after flashing with the new partition table

73s de UT8IA/SO6OO alongside with SP6ZHP crew.